### PR TITLE
Checkout deploy script before deploy

### DIFF
--- a/.github/workflows/deploy-triage-party.yml
+++ b/.github/workflows/deploy-triage-party.yml
@@ -53,12 +53,19 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - name: Setup GCP With Auth
-      uses: google-github-actions/setup-gcloud@v0.3
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: GCP Auth
+      id: 'auth'
+      uses: google-github-actions/auth@v0.5.0
+      with:
+        credentials_json: '${{ secrets.TRIAGE_PARTY_GCP_SA_KEY }}'
+
+    - name: Setup GCP Cloud SDK
+      uses: google-github-actions/setup-gcloud@v0.4
       with:
         project_id: ${{ secrets.GCP_PROJECT_ID }}
-        service_account_key: ${{ secrets.TRIAGE_PARTY_GCP_SA_KEY }}
-        export_default_credentials: true
 
     - name: Deploy Triage Party
       run: ./triage-party/deploy.sh


### PR DESCRIPTION
Cloning repo is required step in the deploy job.

Also uses new GHA gcloud authentication flow.