### PR TITLE
Add NuGet restore benchmarking app

### DIFF
--- a/dotnet-benchmarking/NugetBenchmarking/NugetBenchmarking.csproj
+++ b/dotnet-benchmarking/NugetBenchmarking/NugetBenchmarking.csproj
@@ -1,0 +1,43 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Remove="Newtonsoft.Json" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Autofac" Version="6.3.0" />
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="CsvHelper" Version="27.2.1" />
+    <PackageReference Include="Dapper" Version="2.0.123" />
+    <PackageReference Include="DnsClient" Version="1.6.0" />
+    <PackageReference Include="Elasticsearch.Net" Version="7.17.0" />
+    <PackageReference Include="FluentAssertions" Version="6.5.1" />
+    <PackageReference Include="FluentValidation" Version="10.4.0" />
+    <PackageReference Include="Google.Apis" Version="1.56.0" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.42" />
+    <PackageReference Include="Humanizer" Version="2.14.1" />
+    <PackageReference Include="log4net" Version="2.0.14" />
+    <PackageReference Include="MathNet.Numerics" Version="4.15.0" />
+    <PackageReference Include="MathParser.org-mXparser" Version="4.4.2" />
+    <PackageReference Include="MongoDB.Driver" Version="2.15.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="NLog" Version="4.7.14" />
+    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
+    <PackageReference Include="prometheus-net" Version="6.0.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="SharpCompress" Version="0.30.1" />
+    <PackageReference Include="SharpZipLib" Version="1.3.3" />
+    <PackageReference Include="StackExchange.Redis" Version="2.5.43" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="YamlDotNet" Version="11.2.1" />
+  </ItemGroup>
+</Project>

--- a/dotnet-benchmarking/NugetBenchmarking/Program.cs
+++ b/dotnet-benchmarking/NugetBenchmarking/Program.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Serilog;
+
+namespace NugetBenchmarking
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            // Serilog
+            using var log = new LoggerConfiguration()
+                  .WriteTo.Console()
+                  .CreateLogger();
+            log.Information("Hello, World!");
+        }
+    }
+}

--- a/dotnet-benchmarking/NugetBenchmarking/README.md
+++ b/dotnet-benchmarking/NugetBenchmarking/README.md
@@ -1,0 +1,25 @@
+# NugetBenchmarking
+
+This simple .NET console app's sole purpose is to benchmark the `dotnet
+restore` phase of the build. Its project file is padded with lots of NuGet
+packages (sourced from the NuGet [package gallery](https://www.nuget.org/)) and
+added with the `dotnet add <package name>` command. Since `dotnet` restores
+packages that appear in the project file whether or not they're used, this app
+is quick to compile (basically no business logic), but has lots of
+dependencies. Building this app with the buildpack helps demonstrate
+the efficacy of storing the NuGet cache for rebuild speeds.
+
+## Building
+To observe how long it takes to restore packages on an initial build, run:
+```bash
+pack build nuget-benchmarking -b paketo-buildpacks/dotnet-core
+```
+Note the log output from the `dotnet` CLI indicating how long the restore took. For instance:
+```
+[builder]         Determining projects to restore...
+[builder]         Restored /workspace/NugetBenchmarking.csproj (in 14.24 sec).
+```
+
+Rebuild the app with the same `pack build` command, and see that the package restore phase
+is significantly faster.
+


### PR DESCRIPTION
As we investigate optimizing the .NET buildpack, it'll be useful to have some benchmarking apps that demonstrate how parts of the .NET container build process can be slow. This will make more evident whether our optimizations are effective/worth doing.